### PR TITLE
Fix memory leaks for observing properties

### DIFF
--- a/RxWebKit/Sources/Rx+WebKit.swift
+++ b/RxWebKit/Sources/Rx+WebKit.swift
@@ -18,14 +18,14 @@ extension Reactive where Base: WKWebView {
      Reactive wrapper for `title` property
      */
     public var title: Observable<String?> {
-        return self.observe(String.self, "title")
+        return self.observeWeakly(String.self, "title")
     }
 
     /**
      Reactive wrapper for `loading` property.
      */
     public var loading: Observable<Bool> {
-        return self.observe(Bool.self, "loading")
+        return self.observeWeakly(Bool.self, "loading")
             .map { $0 ?? false }
     }
 
@@ -33,7 +33,7 @@ extension Reactive where Base: WKWebView {
      Reactive wrapper for `estimatedProgress` property.
      */
     public var estimatedProgress: Observable<Double> {
-        return self.observe(Double.self, "estimatedProgress")
+        return self.observeWeakly(Double.self, "estimatedProgress")
             .map { $0 ?? 0.0 }
     }
 
@@ -41,7 +41,7 @@ extension Reactive where Base: WKWebView {
      Reactive wrapper for `url` property.
      */
     public var url: Observable<URL?> {
-        return self.observe(URL.self, "URL")
+        return self.observeWeakly(URL.self, "URL")
     }
 
 
@@ -49,7 +49,7 @@ extension Reactive where Base: WKWebView {
      Reactive wrapper for `canGoBack` property.
      */
     public var canGoBack: Observable<Bool> {
-        return self.observe(Bool.self, "canGoBack")
+        return self.observeWeakly(Bool.self, "canGoBack")
             .map { $0 ?? false }
     }
 
@@ -57,7 +57,7 @@ extension Reactive where Base: WKWebView {
      Reactive wrapper for `canGoForward` property.
      */
     public var canGoForward: Observable<Bool> {
-        return self.observe(Bool.self, "canGoForward")
+        return self.observeWeakly(Bool.self, "canGoForward")
             .map { $0 ?? false }
     }
 }


### PR DESCRIPTION
When I used "Leaks" of instruments for "Example" target, several memory leaks were detected just after launch.
<img width="512" alt="leaks" src="https://user-images.githubusercontent.com/12739806/36932214-703f9f30-1f09-11e8-94f3-aacd92e88ce1.png">


It seems that observing properties by using `observe` causes them.

This PR is to prevent the leaks by using `observeWeakly` instead of `observe` for observing properties.
When using `observeWeakly`, no leaks are detected.
<img width="512" alt="noleaks" src="https://user-images.githubusercontent.com/12739806/36932228-9ee966d6-1f09-11e8-8694-00526839e1b0.png">


I would appreciate if this PR could be reviewed.

Reference: `rx.observeWeakly`
https://github.com/ReactiveX/RxSwift/blob/12cccb171ad9038251af6883807f0290c1d75a5b/Documentation/GettingStarted.md#rxobserveweakly