### PR TITLE
Remove retain cycle in the examples

### DIFF
--- a/Example/FailedRequestViewController.swift
+++ b/Example/FailedRequestViewController.swift
@@ -25,10 +25,11 @@ class FailedRequestViewController: UIViewController {
             .didFailProvisionalNavigation
             .observeOn(MainScheduler.instance)
             .debug("didFailProvisionalNavigation")
-            .subscribe(onNext: {(webView, navigation, error) in
+            .subscribe(onNext: { [weak self] webView, navigation, error in
+                guard let strongSelf = self else { return }
                 let alert = UIAlertController(title: "FailProvisionalNavigation", message: error.localizedDescription, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+                strongSelf.present(alert, animated: true, completion: nil)
             })
             .disposed(by: bag)
     }

--- a/Example/FailedRequestViewController.swift
+++ b/Example/FailedRequestViewController.swift
@@ -26,10 +26,10 @@ class FailedRequestViewController: UIViewController {
             .observeOn(MainScheduler.instance)
             .debug("didFailProvisionalNavigation")
             .subscribe(onNext: { [weak self] webView, navigation, error in
-                guard let strongSelf = self else { return }
+                guard let self = self else { return }
                 let alert = UIAlertController(title: "FailProvisionalNavigation", message: error.localizedDescription, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                strongSelf.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
             })
             .disposed(by: bag)
     }

--- a/Example/JavaScriptAlertPanelViewController.swift
+++ b/Example/JavaScriptAlertPanelViewController.swift
@@ -26,10 +26,10 @@ class JavaScriptAlertPanelViewController: UIViewController {
             .javaScriptAlertPanel
             .debug("javaScriptAlertPanel")
             .subscribe(onNext: { [weak self] webView, message, frame, handler in
-                guard let strongSelf = self else { return }
+                guard let self = self else { return }
                 let alert = UIAlertController(title: "JavaScriptAlertPanel", message: message, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                strongSelf.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
                 handler()
             })
             .disposed(by: bag)

--- a/Example/JavaScriptAlertPanelViewController.swift
+++ b/Example/JavaScriptAlertPanelViewController.swift
@@ -25,10 +25,11 @@ class JavaScriptAlertPanelViewController: UIViewController {
         wkWebView.rx
             .javaScriptAlertPanel
             .debug("javaScriptAlertPanel")
-            .subscribe(onNext: {(webView, message, frame, handler) in
+            .subscribe(onNext: { [weak self] webView, message, frame, handler in
+                guard let strongSelf = self else { return }
                 let alert = UIAlertController(title: "JavaScriptAlertPanel", message: message, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+                strongSelf.present(alert, animated: true, completion: nil)
                 handler()
             })
             .disposed(by: bag)

--- a/Example/JavaScriptConfirmPanelViewController.swift
+++ b/Example/JavaScriptConfirmPanelViewController.swift
@@ -25,10 +25,11 @@ class JavaScriptConfirmPanelViewController: UIViewController {
         wkWebView.rx
             .javaScriptConfirmPanel
             .debug("javaScriptConfirmPanel")
-            .subscribe(onNext: {(webView, message, frame, handler) in
+            .subscribe(onNext: { [weak self] webView, message, frame, handler in
+                guard let strongSelf = self else { return }
                 let alert = UIAlertController(title: "JavaScriptConfirm", message: message, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+                strongSelf.present(alert, animated: true, completion: nil)
                 handler(true)
             })
             .disposed(by: bag)

--- a/Example/JavaScriptConfirmPanelViewController.swift
+++ b/Example/JavaScriptConfirmPanelViewController.swift
@@ -26,10 +26,10 @@ class JavaScriptConfirmPanelViewController: UIViewController {
             .javaScriptConfirmPanel
             .debug("javaScriptConfirmPanel")
             .subscribe(onNext: { [weak self] webView, message, frame, handler in
-                guard let strongSelf = self else { return }
+                guard let self = self else { return }
                 let alert = UIAlertController(title: "JavaScriptConfirm", message: message, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                strongSelf.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
                 handler(true)
             })
             .disposed(by: bag)

--- a/Example/RedirectViewController.swift
+++ b/Example/RedirectViewController.swift
@@ -27,10 +27,10 @@ class RedirectViewController: UIViewController {
             .observeOn(MainScheduler.instance)
             .debug("didReceiveServerRedirectForProvisionalNavigation")
             .subscribe(onNext: { [weak self] webView, navigation in
-                guard let strongSelf = self else { return }
+                guard let self = self else { return }
                 let alert = UIAlertController(title: "Redirect Navigation", message: "you have bene redirected", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                strongSelf.present(alert, animated: true, completion: nil)
+                self.present(alert, animated: true, completion: nil)
             })
             .disposed(by: bag)
     }

--- a/Example/RedirectViewController.swift
+++ b/Example/RedirectViewController.swift
@@ -26,10 +26,11 @@ class RedirectViewController: UIViewController {
             .didReceiveServerRedirectForProvisionalNavigation
             .observeOn(MainScheduler.instance)
             .debug("didReceiveServerRedirectForProvisionalNavigation")
-            .subscribe(onNext: {(webView, navigation) in
+            .subscribe(onNext: { [weak self] webView, navigation in
+                guard let strongSelf = self else { return }
                 let alert = UIAlertController(title: "Redirect Navigation", message: "you have bene redirected", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-                self.present(alert, animated: true, completion: nil)
+                strongSelf.present(alert, animated: true, completion: nil)
             })
             .disposed(by: bag)
     }


### PR DESCRIPTION
Self was strongly referenced in most of the examples, thus creating a dependency cycle. This could easy be verified by checking the #debug logs: isDisposed was never called when navigating back from the controllers.

Considering that people will use the examples as a reference, it seems weird to leave it as it was.