### PR TITLE
Removed unnecessary build option overrides in target settings

### DIFF
--- a/RxWebKit.xcodeproj/project.pbxproj
+++ b/RxWebKit.xcodeproj/project.pbxproj
@@ -597,7 +597,6 @@
 		42F426AA1C66200D001FED46 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -617,7 +616,6 @@
 		42F426AB1C66200D001FED46 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/RxWebKit.xcodeproj/project.pbxproj
+++ b/RxWebKit.xcodeproj/project.pbxproj
@@ -637,7 +637,6 @@
 		42F426D81C6623C5001FED46 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -667,7 +666,6 @@
 		42F426D91C6623C5001FED46 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
This pull request fixes part of #34.

- Removed unnecessary overrides build option in target `RxWebKit` and `Example`.
    - Removed `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=YES` from project file.
    - No settings is same as setting `$(inherited)` flag.
